### PR TITLE
Workaround for absence of advisory lock in YugabyteDB

### DIFF
--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBConnection.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBConnection.java
@@ -16,7 +16,10 @@
 package org.flywaydb.community.database.postgresql.yugabytedb;
 
 import org.flywaydb.core.internal.database.base.Schema;
+import org.flywaydb.core.internal.database.base.Table;
 import org.flywaydb.database.postgresql.PostgreSQLConnection;
+
+import java.util.concurrent.Callable;
 
 public class YugabyteDBConnection extends PostgreSQLConnection {
 
@@ -27,5 +30,10 @@ public class YugabyteDBConnection extends PostgreSQLConnection {
     @Override
     public Schema getSchema(String name) {
         return new YugabyteDBSchema(jdbcTemplate, (YugabyteDBDatabase) database, name);
+    }
+
+    @Override
+    public <T> T lock(Table table, Callable<T> callable) {
+        return new YugabyteDBExecutionTemplate(database.getConfiguration(), jdbcTemplate, table.toString()).execute(callable);
     }
 }

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBConnection.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBConnection.java
@@ -34,6 +34,6 @@ public class YugabyteDBConnection extends PostgreSQLConnection {
 
     @Override
     public <T> T lock(Table table, Callable<T> callable) {
-        return new YugabyteDBExecutionTemplate(database.getConfiguration(), jdbcTemplate, table.toString()).execute(callable);
+        return new YugabyteDBExecutionTemplate(jdbcTemplate, table.toString()).execute(callable);
     }
 }

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -77,7 +77,7 @@ public class YugabyteDBDatabase extends PostgreSQLDatabase {
 
     private void init() {
         try {
-            jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS " + LOCK_TABLE_NAME + " (table_name varchar PRIMARY KEY, locked bool, last_updated timestamp);");
+            jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS " + LOCK_TABLE_NAME + " (table_name varchar PRIMARY KEY, locked bool, last_updated timestamp)");
         } catch (SQLException e) {
             throw new FlywaySqlException("Unable to initialize the lock table", e);
         }

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabaseType.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabaseType.java
@@ -67,4 +67,9 @@ public class YugabyteDBDatabaseType extends PostgreSQLDatabaseType implements Co
     public String getPluginVersion(Configuration config) {
         return YugabyteDBDatabaseExtension.readVersion();
     }
+
+    @Override
+    public String getDriverClass(String url, ClassLoader classLoader) {
+        return url.startsWith("jdbc:yugabytedb:") ? "com.yugabyte.Driver" : super.getDriverClass(url, classLoader);
+    }
 }

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabaseType.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabaseType.java
@@ -68,6 +68,15 @@ public class YugabyteDBDatabaseType extends PostgreSQLDatabaseType implements Co
         return YugabyteDBDatabaseExtension.readVersion();
     }
 
+    /**
+     * Returns the YugabyteDB Smart driver classname if the smart driver is
+     * being used. The plugin will work with the Postgresql JDBC driver also
+     * since the url in that case would start with 'jdbc:postgresql' which would
+     * return the PG JDBC driver class name.
+     * @param url
+     * @param classLoader
+     * @return "com.yugabyte.Driver" if url starts with "jdbc:yugabytedb:"
+     */
     @Override
     public String getDriverClass(String url, ClassLoader classLoader) {
         return url.startsWith("jdbc:yugabytedb:") ? "com.yugabyte.Driver" : super.getDriverClass(url, classLoader);

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBExecutionTemplate.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBExecutionTemplate.java
@@ -1,0 +1,78 @@
+package org.flywaydb.community.database.postgresql.yugabytedb;
+
+import lombok.CustomLog;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.concurrent.Callable;
+
+@CustomLog
+public class YugabyteDBExecutionTemplate {
+
+    private final Configuration configuration;
+    private final JdbcTemplate jdbcTemplate;
+    private final String tableName;
+    private final HashMap<String, Boolean> tableEntries = new HashMap<>();
+
+
+    YugabyteDBExecutionTemplate(Configuration configuration, JdbcTemplate jdbcTemplate, String tableName) {
+        this.configuration = configuration;
+        this.jdbcTemplate = jdbcTemplate;
+        this.tableName = tableName;
+    }
+
+    public <T> T execute(Callable<T> callable) {
+        Exception error = null;
+        try {
+            lock();
+            return callable.call();
+        } catch (RuntimeException e) {
+            error = e;
+            throw e;
+        } catch (Exception e) {
+            error = e;
+            throw new FlywayException(e);
+        } finally {
+            unlock(error);
+        }
+    }
+
+    private void lock() throws SQLException {
+        try {
+            if (!tableEntries.containsKey(tableName)) {
+                try {
+                    jdbcTemplate.execute("INSERT INTO " + YugabyteDBDatabase.LOCK_TABLE_NAME + " VALUES ('" + tableName + "', 'false', NOW());");
+                    tableEntries.put(tableName, true);
+                } catch (SQLException e) {
+                    if ("23505".equals(e.getSQLState())) {
+                        // 23505 == UNIQUE_VIOLATION
+                        LOG.debug("Table entry already added");
+                    } else {
+                        throw new FlywaySqlException("Could not initialize lock for table " + YugabyteDBDatabase.LOCK_TABLE_NAME, e);
+                    }
+                }
+            }
+
+            jdbcTemplate.execute("BEGIN;");
+            jdbcTemplate.queryForBoolean("SELECT locked FROM " + YugabyteDBDatabase.LOCK_TABLE_NAME + " WHERE  table_name = '" + tableName + "' FOR UPDATE;");
+        } catch (SQLException e) {
+            throw new FlywaySqlException("Trying to acquire lock failed", e);
+        }
+    }
+
+    private void unlock(Exception rethrow) throws FlywaySqlException {
+        try {
+            jdbcTemplate.execute("COMMIT;");
+        } catch (SQLException e) {
+            LOG.error("Commit failed: " + e);
+            if (rethrow == null) {
+                throw new FlywaySqlException("Commit failed", e);
+            }
+        }
+    }
+
+}

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBExecutionTemplate.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBExecutionTemplate.java
@@ -5,13 +5,9 @@ import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.internal.exception.FlywaySqlException;
 import org.flywaydb.core.internal.jdbc.JdbcTemplate;
-import org.flywaydb.core.internal.jdbc.RowMapper;
 
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.util.ArrayList;
+import java.sql.*;
 import java.util.HashMap;
-import java.util.List;
 import java.util.concurrent.Callable;
 
 @CustomLog
@@ -34,7 +30,6 @@ public class YugabyteDBExecutionTemplate {
     public <T> T execute(Callable<T> callable) {
         Exception error = null;
         try {
-            System.out.println("Lock Connection " + jdbcTemplate.getConnection().toString() + ", thread: " + Thread.currentThread().getName());
             lock();
             return callable.call();
         } catch (RuntimeException e) {
@@ -44,23 +39,26 @@ public class YugabyteDBExecutionTemplate {
             error = e;
             throw new FlywayException(e);
         } finally {
-            System.out.println("Unlock Connection " + jdbcTemplate.getConnection().toString() + ", thread: " + Thread.currentThread().getName());
             unlock(error);
         }
     }
 
     private void lock() {
+        Exception exception = null;
         boolean txStarted = false;
+        Statement statement = null;
         try {
+            statement = jdbcTemplate.getConnection().createStatement();
+
             if (!tableEntries.containsKey(tableName)) {
                 try {
-                    jdbcTemplate.execute("INSERT INTO " + YugabyteDBDatabase.LOCK_TABLE_NAME + " VALUES ('" + tableName + "', 'false', NOW());");
+                    statement.executeUpdate("INSERT INTO " + YugabyteDBDatabase.LOCK_TABLE_NAME + " VALUES ('" + tableName + "', 'false', NOW())");
                     tableEntries.put(tableName, true);
-                    LOG.warn("Inserted a record for " + tableName);
+                    LOG.info(Thread.currentThread().getName() + "> Inserted a record for " + tableName);
                 } catch (SQLException e) {
                     if ("23505".equals(e.getSQLState())) {
                         // 23505 == UNIQUE_VIOLATION
-                        LOG.debug("Table entry already added");
+                        LOG.debug(Thread.currentThread().getName() + "> Table entry already added for " + tableName);
                     } else {
                         throw new FlywaySqlException("Could not initialize lock for table " + YugabyteDBDatabase.LOCK_TABLE_NAME, e);
                     }
@@ -68,73 +66,98 @@ public class YugabyteDBExecutionTemplate {
             }
 
             boolean locked;
+            String selectForUpdate = "SELECT locked, last_updated FROM " + YugabyteDBDatabase.LOCK_TABLE_NAME + " WHERE table_name = '" + tableName + "' FOR UPDATE";
+            String updateLocked = "UPDATE " + YugabyteDBDatabase.LOCK_TABLE_NAME + " SET locked = true, last_updated = NOW() WHERE table_name = '" + tableName + "'";
             do {
-                jdbcTemplate.execute("BEGIN;");
+                statement.execute("BEGIN");
                 txStarted = true;
-                RowMapper<ArrayList> rm = resultSet -> {
-                    ArrayList e = new ArrayList();
-                    e.add(resultSet.getBoolean("locked"));
-                    e.add(resultSet.getTimestamp("last_updated"));
-                    return e;
-                };
-                List r = jdbcTemplate.query("SELECT locked, last_updated FROM " + YugabyteDBDatabase.LOCK_TABLE_NAME + " WHERE table_name = '" + tableName + "' FOR UPDATE;", rm);
-                ArrayList row = (ArrayList) r.get(0);
-                locked = (Boolean) row.get(0);
-                Timestamp ts = (Timestamp) row.get(1);
-                if (locked) {
-                    // Was it too long ago?
-                    if ((System.currentTimeMillis() - ts.getTime()) > (MAX_FLYWAY_OP_DURATION_SEC * 1000)) {
-                        LOG.warn("Some other Flyway operation is in-progress for > " + MAX_FLYWAY_OP_DURATION_SEC
-                                + "s. Continuing without waiting for it to get over.");
-                        jdbcTemplate.execute("UPDATE " + YugabyteDBDatabase.LOCK_TABLE_NAME + " SET locked = true, last_updated = NOW() WHERE table_name = '" + tableName + "';");
+                ResultSet rs = statement.executeQuery(selectForUpdate);
+                if (rs.next()) {
+                    locked = rs.getBoolean("locked");
+                    Timestamp ts = rs.getTimestamp("last_updated");
+
+                    if (locked) {
+                        // Was it too long ago?
+                        if ((System.currentTimeMillis() - ts.getTime()) > (MAX_FLYWAY_OP_DURATION_SEC * 1000)) {
+                            LOG.warn("Some other Flyway operation is in progress for > " + MAX_FLYWAY_OP_DURATION_SEC
+                                    + "s, continuing without waiting for it to get over");
+                            statement.executeUpdate(updateLocked);
+                            break;
+                        }
+                        // End transaction and retry after a sleep
+                        statement.execute("COMMIT");
+                        txStarted = false;
+                        try {
+                            LOG.info(Thread.currentThread().getName() + "> Another Flyway operation is in progress. Allowing it to complete");
+                            Thread.sleep(1000);
+                        } catch (InterruptedException ie) {
+                            throw new FlywayException("Interrupted while waiting to get a lock: " + ie);
+                        }
+                    } else {
+                        LOG.debug(Thread.currentThread().getName() + "> Setting locked = true");
+                        statement.executeUpdate(updateLocked);
                         break;
                     }
-                    // End transaction and retry after a sleep
-                    jdbcTemplate.execute("COMMIT;");
-                    txStarted = false;
-                    try {
-                        LOG.info(Thread.currentThread().getName() + " Sleeping for a second");
-                        Thread.sleep(1000);
-                    } catch (InterruptedException ie) {
-                        throw new FlywayException("Interrupted while waiting to get a lock: " + ie);
-                    }
                 } else {
-                    LOG.info("Setting locked = true ...");
-                    jdbcTemplate.execute("UPDATE " + YugabyteDBDatabase.LOCK_TABLE_NAME + " SET locked = true, last_updated = NOW() WHERE table_name = '" + tableName + "';");
-                    break;
+                    // For some reason the record was not found
+                    tableEntries.remove(tableName);
+                    throw new FlywayException("Unable to perform lock action as " + YugabyteDBDatabase.LOCK_TABLE_NAME + " is not initialized");
                 }
             } while (locked);
         } catch (SQLException e) {
-            throw new FlywaySqlException("Trying to acquire lock failed", e);
+            LOG.error(Thread.currentThread().getName() + "> Unable to perform lock action", e);
+            exception = new FlywaySqlException("Unable to perform lock action", e);
+            throw (FlywaySqlException) exception;
         } finally {
             if (txStarted) {
                 try {
-                    jdbcTemplate.execute("COMMIT;");
-                    LOG.info("Completed the tx to set locked = true");
+                    statement.execute("COMMIT");
+                    LOG.debug(Thread.currentThread().getName() + "> Completed the tx to set locked = true");
                 } catch (SQLException e) {
-                    throw new FlywaySqlException("Trying to acquire lock failed", e);
+                    if (exception == null) {
+                        throw new FlywaySqlException("Failed to commit the tx to set locked = true", e);
+                    }
+                    LOG.error(Thread.currentThread().getName() + "> Failed to commit the tx to set locked = true", e);
                 }
             }
         }
     }
 
-    private void unlock(Exception rethrow) throws FlywaySqlException {
+    private void unlock(Exception rethrow) {
+        Statement statement = null;
         try {
-            jdbcTemplate.execute("BEGIN;");
-            boolean locked = jdbcTemplate.queryForBoolean("SELECT locked FROM " + YugabyteDBDatabase.LOCK_TABLE_NAME + " WHERE table_name = '" + tableName + "' FOR UPDATE;");
-            if (locked) {
-                jdbcTemplate.execute("UPDATE " + YugabyteDBDatabase.LOCK_TABLE_NAME + " SET locked = false, last_updated = NOW() WHERE table_name = '" + tableName + "';");
-            } else {
-                // Unexpected. Only time this may happen is when callable took too long to complete
-                // and another thread forcefully reset it.
-                LOG.warn("Unlock failed. Check your Flyway operation");
-                throw new FlywayException("Unlock failed. Check your Flyway operation and try again");
+            statement = jdbcTemplate.getConnection().createStatement();
+            statement.execute("BEGIN");
+            ResultSet rs = statement.executeQuery("SELECT locked FROM " + YugabyteDBDatabase.LOCK_TABLE_NAME + " WHERE table_name = '" + tableName + "' FOR UPDATE");
+
+            if (rs.next()) {
+                boolean locked = rs.getBoolean("locked");
+                if (locked) {
+                    statement.executeUpdate("UPDATE " + YugabyteDBDatabase.LOCK_TABLE_NAME + " SET locked = false, last_updated = NOW() WHERE table_name = '" + tableName + "'");
+                } else {
+                    // Unexpected. This may happen only when callable took too long to complete
+                    // and another thread forcefully reset it.
+                    String msg = "Unlock failed but the Flyway operation may have succeeded. Check your Flyway operation before re-trying";
+                    LOG.warn(Thread.currentThread().getName() + "> " + msg);
+                    if (rethrow == null) {
+                        throw new FlywayException(msg);
+                    }
+                }
             }
-            jdbcTemplate.execute("COMMIT;");
         } catch (SQLException e) {
-            LOG.error("Commit failed: " + e);
             if (rethrow == null) {
-                throw new FlywaySqlException("Commit failed", e);
+                rethrow = new FlywayException("Unable to perform unlock action", e);
+                throw (FlywaySqlException) rethrow;
+            }
+            LOG.warn("Unable to perform unlock action " + e);
+        } finally {
+            try {
+                statement.execute("COMMIT");
+            } catch (SQLException e) {
+                if (rethrow == null) {
+                    throw new FlywaySqlException("Failed to commit unlock action", e);
+                }
+                LOG.error("Failed to commit unlock action", e);
             }
         }
     }

--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBExecutionTemplate.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBExecutionTemplate.java
@@ -5,9 +5,13 @@ import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.internal.exception.FlywaySqlException;
 import org.flywaydb.core.internal.jdbc.JdbcTemplate;
+import org.flywaydb.core.internal.jdbc.RowMapper;
 
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 @CustomLog
@@ -17,6 +21,8 @@ public class YugabyteDBExecutionTemplate {
     private final JdbcTemplate jdbcTemplate;
     private final String tableName;
     private final HashMap<String, Boolean> tableEntries = new HashMap<>();
+
+    private final long MAX_FLYWAY_OP_DURATION_SEC = 30;
 
 
     YugabyteDBExecutionTemplate(Configuration configuration, JdbcTemplate jdbcTemplate, String tableName) {
@@ -28,6 +34,7 @@ public class YugabyteDBExecutionTemplate {
     public <T> T execute(Callable<T> callable) {
         Exception error = null;
         try {
+            System.out.println("Lock Connection " + jdbcTemplate.getConnection().toString() + ", thread: " + Thread.currentThread().getName());
             lock();
             return callable.call();
         } catch (RuntimeException e) {
@@ -37,16 +44,19 @@ public class YugabyteDBExecutionTemplate {
             error = e;
             throw new FlywayException(e);
         } finally {
+            System.out.println("Unlock Connection " + jdbcTemplate.getConnection().toString() + ", thread: " + Thread.currentThread().getName());
             unlock(error);
         }
     }
 
-    private void lock() throws SQLException {
+    private void lock() {
+        boolean txStarted = false;
         try {
             if (!tableEntries.containsKey(tableName)) {
                 try {
                     jdbcTemplate.execute("INSERT INTO " + YugabyteDBDatabase.LOCK_TABLE_NAME + " VALUES ('" + tableName + "', 'false', NOW());");
                     tableEntries.put(tableName, true);
+                    LOG.warn("Inserted a record for " + tableName);
                 } catch (SQLException e) {
                     if ("23505".equals(e.getSQLState())) {
                         // 23505 == UNIQUE_VIOLATION
@@ -57,15 +67,69 @@ public class YugabyteDBExecutionTemplate {
                 }
             }
 
-            jdbcTemplate.execute("BEGIN;");
-            jdbcTemplate.queryForBoolean("SELECT locked FROM " + YugabyteDBDatabase.LOCK_TABLE_NAME + " WHERE  table_name = '" + tableName + "' FOR UPDATE;");
+            boolean locked;
+            do {
+                jdbcTemplate.execute("BEGIN;");
+                txStarted = true;
+                RowMapper<ArrayList> rm = resultSet -> {
+                    ArrayList e = new ArrayList();
+                    e.add(resultSet.getBoolean("locked"));
+                    e.add(resultSet.getTimestamp("last_updated"));
+                    return e;
+                };
+                List r = jdbcTemplate.query("SELECT locked, last_updated FROM " + YugabyteDBDatabase.LOCK_TABLE_NAME + " WHERE table_name = '" + tableName + "' FOR UPDATE;", rm);
+                ArrayList row = (ArrayList) r.get(0);
+                locked = (Boolean) row.get(0);
+                Timestamp ts = (Timestamp) row.get(1);
+                if (locked) {
+                    // Was it too long ago?
+                    if ((System.currentTimeMillis() - ts.getTime()) > (MAX_FLYWAY_OP_DURATION_SEC * 1000)) {
+                        LOG.warn("Some other Flyway operation is in-progress for > " + MAX_FLYWAY_OP_DURATION_SEC
+                                + "s. Continuing without waiting for it to get over.");
+                        jdbcTemplate.execute("UPDATE " + YugabyteDBDatabase.LOCK_TABLE_NAME + " SET locked = true, last_updated = NOW() WHERE table_name = '" + tableName + "';");
+                        break;
+                    }
+                    // End transaction and retry after a sleep
+                    jdbcTemplate.execute("COMMIT;");
+                    txStarted = false;
+                    try {
+                        LOG.info(Thread.currentThread().getName() + " Sleeping for a second");
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ie) {
+                        throw new FlywayException("Interrupted while waiting to get a lock: " + ie);
+                    }
+                } else {
+                    LOG.info("Setting locked = true ...");
+                    jdbcTemplate.execute("UPDATE " + YugabyteDBDatabase.LOCK_TABLE_NAME + " SET locked = true, last_updated = NOW() WHERE table_name = '" + tableName + "';");
+                    break;
+                }
+            } while (locked);
         } catch (SQLException e) {
             throw new FlywaySqlException("Trying to acquire lock failed", e);
+        } finally {
+            if (txStarted) {
+                try {
+                    jdbcTemplate.execute("COMMIT;");
+                    LOG.info("Completed the tx to set locked = true");
+                } catch (SQLException e) {
+                    throw new FlywaySqlException("Trying to acquire lock failed", e);
+                }
+            }
         }
     }
 
     private void unlock(Exception rethrow) throws FlywaySqlException {
         try {
+            jdbcTemplate.execute("BEGIN;");
+            boolean locked = jdbcTemplate.queryForBoolean("SELECT locked FROM " + YugabyteDBDatabase.LOCK_TABLE_NAME + " WHERE table_name = '" + tableName + "' FOR UPDATE;");
+            if (locked) {
+                jdbcTemplate.execute("UPDATE " + YugabyteDBDatabase.LOCK_TABLE_NAME + " SET locked = false, last_updated = NOW() WHERE table_name = '" + tableName + "';");
+            } else {
+                // Unexpected. Only time this may happen is when callable took too long to complete
+                // and another thread forcefully reset it.
+                LOG.warn("Unlock failed. Check your Flyway operation");
+                throw new FlywayException("Unlock failed. Check your Flyway operation and try again");
+            }
             jdbcTemplate.execute("COMMIT;");
         } catch (SQLException e) {
             LOG.error("Commit failed: " + e);


### PR DESCRIPTION
- Replace the use of pg advisory locks in the Postgresql plugin with `SELECT ... FOR UPDATE` in the YugabyteDB plugin
  - The retries are attempted using `RetryStrategy` which is also employed by the Postgresql plugin.
  - Most logic is in `YugabyteDBExecutionTemplate`
 
- Also, override `PostgreSQLDatabaseType.getDriverClass()` so YugabyteDB smart driver is supported by the YugabyteDB plugin.

Testing:
Ran the tests in flyway-tests repository with some modifications. PR raised [here](https://github.com/yugabyte/flyway-tests/pull/2).

Note:
This PR will be later opened against the upstream main branch.