### PR TITLE
Use lowercase tablename for the SELECT query to correctly fetch its columns

### DIFF
--- a/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
+++ b/flyway-database-yugabytedb/src/main/java/org/flywaydb/community/database/postgresql/yugabytedb/YugabyteDBDatabase.java
@@ -37,7 +37,8 @@ import java.util.List;
 public class YugabyteDBDatabase extends PostgreSQLDatabase {
 
     public static final String LOCK_TABLE_NAME = "YB_FLYWAY_LOCK_TABLE";
-    private static final String LOCK_TABLE_SCHEMA_SQL = "SELECT table_name, column_name FROM information_schema.columns WHERE table_name = '" + LOCK_TABLE_NAME + "'";
+    // Using table name in lower case, see https://github.com/flyway/flyway-community-db-support/issues/97
+    private static final String LOCK_TABLE_SCHEMA_SQL = "SELECT table_name, column_name FROM information_schema.columns WHERE table_name = '" + LOCK_TABLE_NAME.toLowerCase() + "'";
     private static final String DROP_LOCK_TABLE_IF_EXISTS_DDL = "DROP TABLE IF EXISTS " + LOCK_TABLE_NAME;
     /**
      * This table is used to enforce locking through SELECT ... FOR UPDATE on a


### PR DESCRIPTION
- Fixes this issue on the upstream repo: `https://github.com/flyway/flyway-community-db-support/issues/97`
- Verified with the modified tests [here](https://github.com/yugabyte/flyway-tests/pull/4)